### PR TITLE
feat: filter transactions and balance by product address

### DIFF
--- a/frontend/src/components/RewardPoolCard.tsx
+++ b/frontend/src/components/RewardPoolCard.tsx
@@ -6,10 +6,10 @@ import TwoColumnSection from './TwoColumnSection';
 import DataGrid from './DataGrid';
 import ItemValueRow from './ItemValueRow';
 import { useRewardVaultDetails } from '@/hooks/useRewardVault';
-import { getVaultTotalValue } from '@/helpers/rewardVault';
+import { getVaultTotalValuePerAddress } from '@/helpers/rewardVault';
 import { truncateAddress } from '@/utils/common';
 import PanelContent from './PanelContent';
-import { VAULT_ID } from '@/utils/constants';
+import { DPP_ID, VAULT_ID } from '@/utils/constants';
 
 interface RewardPoolCardProps {
   opacity?: number;
@@ -102,7 +102,7 @@ const RewardPoolCard: React.FC<RewardPoolCardProps> = ({
               <ItemValueRow
                 rowState={getRowState('maintenanceRewardsRemaining')}
                 label="Maintenance Rewards remaining"
-                value={isSuccess && rewardDetails && getVaultTotalValue(rewardDetails)}
+                value={isSuccess && rewardDetails && getVaultTotalValuePerAddress(rewardDetails, DPP_ID)}
               />
               {/* NOTE: Supply - Balance */}
               {/* TODO: Get the balance information contained in `rewardDetails` */}

--- a/frontend/src/helpers/rewardVault.ts
+++ b/frontend/src/helpers/rewardVault.ts
@@ -111,7 +111,7 @@ interface RewardVaultData {
  * console.log(`Loaded vault: ${vaultData.vaultId}`);
  * ```
  */
-function extractRewardVaultData(jsonData: IotaObjectResponse): RewardVaultData {
+function extractRewardVaultData(jsonData: IotaObjectResponse, productIdToFilter: string): RewardVaultData {
   const data = jsonData.data as IotaObjectData;
   // @ts-expect-error - TODO: Better understand the Iota types and make use of it
   const vault = data.content?.fields;
@@ -409,8 +409,12 @@ function isVaultEmpty(data: RewardVaultData): boolean {
  * console.log(`Total Value Locked: ${tvl} LCC`);
  * ```
  */
-function getVaultTotalValue(data: RewardVaultData): string {
-  return formatLCCBalance(data.totalBalance.toString()) + ` ${data.lccTypeName}`;
+function getVaultTotalValuePerAddress(data: RewardVaultData, address: string): string {
+  let amount = "0";
+  if (data.balancesByAddress.has(address)) {
+    amount = formatLCCBalance(data.balancesByAddress.get(address)!.balance);
+  }
+  return amount + ` ${data.lccTypeName}`;
 }
 
 /**
@@ -505,7 +509,7 @@ export {
   formatLCCBalance,
   getAddressesAboveThreshold,
   isVaultEmpty,
-  getVaultTotalValue,
+  getVaultTotalValuePerAddress,
   extractCoinDefinition,
   parseCoinDefinition,
   getLCCPackageId

--- a/frontend/src/hooks/useRewardTransactions.ts
+++ b/frontend/src/hooks/useRewardTransactions.ts
@@ -2,7 +2,7 @@
 
 import { extractRewardTransactionData } from "@/helpers/rewardVaultTransactions";
 import { useNotarizationSent } from "@/providers/appProvider";
-import { REQUEST_SIZE_LIMIT, VAULT_ID } from "@/utils/constants";
+import { DPP_ID, REQUEST_SIZE_LIMIT, VAULT_ID } from "@/utils/constants";
 import { useIotaClientQuery } from "@iota/dapp-kit";
 
 // TODO: Document
@@ -24,7 +24,7 @@ export function useRewardTransactions() {
   });
 
   return {
-    rewardTransactions: data && extractRewardTransactionData(data.data),
+    rewardTransactions: data && extractRewardTransactionData(data.data, DPP_ID),
     isSuccess,
     isLoading,
     isError,

--- a/frontend/src/hooks/useRewardVault.ts
+++ b/frontend/src/hooks/useRewardVault.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { extractRewardVaultData } from "@/helpers/rewardVault";
+import { DPP_ID } from "@/utils/constants";
 import { useIotaClientQuery } from "@iota/dapp-kit";
 
 // TODO: document the purpose of this hook
@@ -11,7 +12,7 @@ export function useRewardVaultDetails(vaultId: string) {
   });
 
   return {
-    rewardDetails: data?.data && extractRewardVaultData(data),
+    rewardDetails: data?.data && extractRewardVaultData(data, DPP_ID),
     isSuccess,
     isLoading,
     isError,

--- a/frontend/src/hooks/useServiceHistory.ts
+++ b/frontend/src/hooks/useServiceHistory.ts
@@ -2,7 +2,7 @@
 
 import { extractServiceTransactionData } from "@/helpers/serviceHistory";
 import { useNotarizationSent } from "@/providers/appProvider";
-import { REQUEST_SIZE_LIMIT, VAULT_ID } from "@/utils/constants";
+import { DPP_ID, REQUEST_SIZE_LIMIT, VAULT_ID } from "@/utils/constants";
 import { useIotaClientQuery } from "@iota/dapp-kit";
 
 // TODO: document the purpose of this hook
@@ -25,7 +25,7 @@ export function useServiceHistory() {
   });
 
   return {
-    serviceHistory: data && extractServiceTransactionData(data.data),
+    serviceHistory: data && extractServiceTransactionData(data.data, DPP_ID),
     isSuccess,
     isLoading,
     isError,


### PR DESCRIPTION
One vault may contain two or more products and without a proper filter by product address it leads to balance account over the actual limit.

<img width="1418" height="614" alt="image" src="https://github.com/user-attachments/assets/10dda4bf-2082-4086-9b78-2e3ca6757adc" />

The image above shows a right balance after a proper product address filter.

