### PR TITLE
feat: leverage css coarse condition to provide different "Start Tour" button for "mobile" or desktop

### DIFF
--- a/frontend/src/components/IntroSlide12.tsx
+++ b/frontend/src/components/IntroSlide12.tsx
@@ -7,16 +7,8 @@ import SlideImage from './SlideImage';
 import SlideContent from './SlideContent';
 import SlideTitle from './SlideTitle';
 import SlideDescription from './SlideDescription';
-import ActionButtons from './ActionButtons';
-import { useRouter } from 'next/navigation';
 
 const IntroSlide12: React.FC = () => {
-  const router = useRouter();
-
-  const handleStartGuidedTour = () => {
-    router.push('/explore-guided');
-  };
-
   return (
     <ImageTextLayout>
       <SlideImage
@@ -29,23 +21,24 @@ const IntroSlide12: React.FC = () => {
         <SlideTitle size="large">Ready to Begin?</SlideTitle>
         <SlideDescription>
           <span>{"Click to start the guided demo as a Service Technician!"}</span>
-          <Link
-            className='not-pointer-coarse:hidden inline italic text-blue-700'
-            target='_blank'
-            href={"nightly://v1?network=iota&url=https://dpp.demo.iota.org/explore-guided"}>
-            {" "}
-            {"If you are in a mobile device, try use the nightly wallet"}
-            {" "}
-            <svg className='inline align-baseline' xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 3h6v6" /><path d="M10 14 21 3" /><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /></svg>
-          </Link>
         </SlideDescription>
-        <ActionButtons
-          primaryButton={{
-            text: "Start Tour",
-            onClick: handleStartGuidedTour,
-            variant: "primary"
-          }}
-        />
+
+        <div className="py-6 flex flex-col md:flex-row gap-6 items-center">
+          <Link
+            className='pointer-coarse:hidden w-fit bg-blue-600 text-white hover:bg-blue-700 px-8 py-4 rounded-full text-lg font-medium transition-all cursor-pointer duration-300  hover:shadow-lg transform hover:scale-102'
+            href={"/explore-guided"}
+            target='_self'
+          >
+            {"Start Tour"}
+          </Link>
+          <Link
+            className='not-pointer-coarse:hidden nw-fit bg-blue-600 text-white hover:bg-blue-700 px-8 py-4 rounded-full text-lg font-medium transition-all cursor-pointer duration-300  hover:shadow-lg transform hover:scale-102'
+            target='_blank'
+            href={"nightly://v1?network=iota&url=https://dpp.demo.iota.org/explore-guided"}
+          >
+            {"Start Tour"}
+          </Link>
+        </div>
       </SlideContent>
     </ImageTextLayout>
   );


### PR DESCRIPTION
The "Start Tour" button behaves differently for different type of devices. For devices operating with "coarse pointer" (mobile) it redirects to Nightly wallet, otherwise (desktop) it navigates to `/explore-guided`.

The change is applied over Introduction Slide 12.

<img width="1970" height="2278" alt="image" src="https://github.com/user-attachments/assets/e951e89b-d238-4182-a802-bc8a36036506" />
