### PR TITLE
refactor: replace small text to extra large text

### DIFF
--- a/frontend/src/components/ClientCard.tsx
+++ b/frontend/src/components/ClientCard.tsx
@@ -38,8 +38,8 @@ const ClientCard: React.FC<ClientCardProps> = ({
       </div>
 
       <div className="p-3 md:p-4">
-        <h4 className="text-sm md:text-lg text-gray-900 font-semibold mb-1">{title}</h4>
-        <p className="text-xs md:text-sm text-gray-600">{description}</p>
+        <h4 className="text-base md:text-lg text-gray-900 font-semibold mb-1">{title}</h4>
+        <p className="text-base md:text-xl text-gray-600">{description}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/IntroSlide11.tsx
+++ b/frontend/src/components/IntroSlide11.tsx
@@ -86,7 +86,7 @@ const IntroSlide11: React.FC = () => {
           translateY={0}
         >
           <div className="text-black/80">
-            <h4 className="text-sm md:text-sm">Both wallets enable secure interaction with this demo without requiring any token balance.</h4>
+            <h4 className="text-base md:text-xl">Both wallets enable secure interaction with this demo without requiring any token balance.</h4>
           </div>
         </NoticeCard>
       </FeaturesGrid>


### PR DESCRIPTION
This refactor makes text at IntroSlide11 consistent with all other slides.

<img width="2592" height="2180" alt="image" src="https://github.com/user-attachments/assets/7a573b64-51c3-4d14-8cd6-4a9851c55497" />
