### PR TITLE
refactor: add background to navigation controls on slides

### DIFF
--- a/frontend/src/app/introduction/[slide]/page.tsx
+++ b/frontend/src/app/introduction/[slide]/page.tsx
@@ -57,6 +57,23 @@ export default function IntroductionPage() {
                   <IntroSlideManager currentSlide={currentSlide} />
                 </IntroSlide>
               </TutorialScrollContainer>
+              <div className="sticky bottom-0 left-0 w-full h-20 bg-transparent z-50">
+                <SlideCounter
+                  current={currentSlide}
+                  total={totalSlides}
+                />
+                <NavigationHint
+                  text="Use arrow keys or click to navigate"
+                  opacity={100}
+                  delay={0.5}
+                />
+                <NavigationButtons
+                  onPrevious={goPrevious}
+                  onNext={goNext}
+                  canGoPrevious={canGoPrevious}
+                  canGoNext={canGoNext}
+                />
+              </div>
             </TutorialCard>
           </MainContent>
         </GridContainer>
@@ -64,23 +81,6 @@ export default function IntroductionPage() {
       {/* Navigation Overlays */}
       <ProgressBar progress={progress} />
 
-      <SlideCounter
-        current={currentSlide}
-        total={totalSlides}
-      />
-
-      <NavigationButtons
-        onPrevious={goPrevious}
-        onNext={goNext}
-        canGoPrevious={canGoPrevious}
-        canGoNext={canGoNext}
-      />
-
-      <NavigationHint
-        text="Use arrow keys or click to navigate"
-        opacity={100}
-        delay={0.5}
-      />
     </>
   );
 }

--- a/frontend/src/components/NavigationButtons.tsx
+++ b/frontend/src/components/NavigationButtons.tsx
@@ -16,7 +16,7 @@ const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   canGoNext = true
 }) => {
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex items-center gap-3">
+    <div className="absolute bottom-5 right-6 z-50 flex items-center gap-3">
       <button
         disabled={!canGoPrevious}
         onClick={onPrevious}

--- a/frontend/src/components/NavigationHint.tsx
+++ b/frontend/src/components/NavigationHint.tsx
@@ -15,7 +15,7 @@ const NavigationHint: React.FC<NavigationHintProps> = ({
 }) => {
   return (
     <div
-      className={`absolute bottom-6 left-1/2 transform -translate-x-1/2 z-40 opacity-${opacity} max-lg:hidden`}
+      className={`absolute bottom-5 left-1/2 transform -translate-x-1/2 z-40 opacity-${opacity} max-lg:hidden`}
       style={{
         transition: `opacity 0.6s ease-out ${delay}s`
       }}

--- a/frontend/src/components/SlideCounter.tsx
+++ b/frontend/src/components/SlideCounter.tsx
@@ -13,7 +13,7 @@ const SlideCounter: React.FC<SlideCounterProps> = ({
 }) => {
   return (
     <div
-      className="fixed bottom-6 left-6 bg-black/30 backdrop-blur-md text-white z-[80] rounded-full text-sm px-3 py-2 font-medium">
+      className="absolute bottom-5 left-6 bg-black/30 backdrop-blur-md text-white z-[80] rounded-full text-sm px-3 py-2 font-medium">
       {current} of {total}
     </div>
   );


### PR DESCRIPTION
Navigation controls are wrapped in an element sticky to the bottom of the slide card and pass over the content in the scroll.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/b337299d-9a6a-4953-8820-1408f0c720f4" />
