### PR TITLE
feat: crop first line of tutorial step description when presenting as drawer

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -174,6 +174,13 @@ html {
 /* .relative { position: relative; } */
 /* .absolute { position: absolute; } */
 
+div.summarize p {
+  width: 30ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Directives for theme preference */
 /* @media (prefers-color-scheme: dark) { */
 /*   :root { */

--- a/frontend/src/components/GuidedSidebar.tsx
+++ b/frontend/src/components/GuidedSidebar.tsx
@@ -293,7 +293,7 @@ const DrawerOtherwise: React.FC<DrawerOtherwiseProps> = ({
             </h2>
             <div className={clsx([
               "text-base text-gray-700 leading-relaxed space-y-4 select-none",
-              !isExpanded && "h-0"
+              !isExpanded && "h-7 summarize"
             ])}
               style={{
                 transition: "height 0.3s cubic-bezier(0.2, 0, 0, 1)",

--- a/frontend/src/components/TwoColumnLayout.tsx
+++ b/frontend/src/components/TwoColumnLayout.tsx
@@ -61,7 +61,7 @@ const OneColumnOtherwise: React.FC<OneColumnOtherwiseProps> = ({
 }) => {
   return (
     <div
-      className='lg:hidden grid grid-cols-1 h-full overflow-hidden transition-all duration-700 ease-out gap-4'
+      className='lg:hidden grid grid-cols-1 h-full overflow-hidden transition-all duration-700 ease-out gap-10'
       style={{
         opacity: opacity / 100,
         transition: `opacity ${delay}s ease-out`


### PR DESCRIPTION
#### With drawer
Crop the first line of step description when presenting the drawer.

<img height="600" src="https://github.com/user-attachments/assets/084e523f-c226-4cd7-a814-0a9b3dbac32d" />

#### Without drawer
Do not show cropped when not in the drawer.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/40c5931f-aa8e-40af-aece-ac7296f299ee" />

