### PR TITLE
fix: gap between image and text

### DIFF
--- a/frontend/src/components/ImageTextLayout.tsx
+++ b/frontend/src/components/ImageTextLayout.tsx
@@ -11,7 +11,7 @@ interface ImageTextLayoutProps {
 
 const ImageTextLayout: React.FC<ImageTextLayoutProps> = ({
   children,
-  gap = "gap-4",
+  gap = "gap-4 sm:gap-8 lg:gap-12",
   pb = "pb-0",
   maxWidth = "max-w-6xl",
 }) => {


### PR DESCRIPTION
<img height="600" alt="Screenshot 2025-10-20 at 16 55 53" src="https://github.com/user-attachments/assets/f57d35e7-b514-48cd-8e02-a1a6b429111f" />
