### PR TITLE
chore: update node version on docker to v24

### DIFF
--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:20-bullseye
+FROM node:24-bullseye
 
 ARG APP_ENV
 ARG NEXT_PUBLIC_EXPLORER_URL


### PR DESCRIPTION
Update frontend docker to use Node v24.