### PR TITLE
refactor: nightly wallet check

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -36,9 +36,11 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   // This effect only works because this module is running on client side.
   // Be aware there is no `window` on server side.
   React.useEffect(() => {
-    // @ts-expect-error - NOTE: `nightly` is not found at Window and globalThis
-    const nightlyIota = window.nightly?.iota;
-    setInNightlyWallet(nightlyIota != null);
+    if (window != null) {
+      // @ts-expect-error - NOTE: `nightly` is not found at Window and globalThis
+      const nightlyIota = window.nightly?.iota;
+      setInNightlyWallet(nightlyIota != null);
+    }
   }, []);
 
   return (

--- a/frontend/src/components/CardHeader.tsx
+++ b/frontend/src/components/CardHeader.tsx
@@ -8,8 +8,6 @@
 import React from 'react';
 import Link from 'next/link';
 
-import clsx from 'clsx';
-
 import { CARD_HEADER } from '@/contents/common';
 import { useNightlyWallet } from '@/providers/appProvider';
 
@@ -46,6 +44,12 @@ const CardHeader: React.FC<CardHeaderProps> = ({
 }) => {
   const { inNightlyWallet } = useNightlyWallet();
 
+  // Do not render the header if showing from inside NightlyWallet.
+  if (inNightlyWallet) {
+    console.warn('Rendering from inside NightlyWallet');
+    return;
+  }
+
   const getButtonStyle = () => {
     if (variation === 'primary') {
       return BUTTON_PRIMARY_STYLE;
@@ -55,10 +59,9 @@ const CardHeader: React.FC<CardHeaderProps> = ({
 
   return (
     <div
-      className={clsx([
-        'flex-shrink-0 border-b border-gray-200 bg-slate-100 px-6 py-3 text-xs text-gray-500',
-        inNightlyWallet && 'hidden',
-      ])}
+      className={
+        'flex-shrink-0 border-b border-gray-200 bg-slate-100 px-6 py-3 text-xs text-gray-500'
+      }
     >
       <div className='flex w-full items-center justify-between gap-2 leading-1'>
         {!canGoBack && <h4>{title}</h4>}


### PR DESCRIPTION
Problem:
Sometimes the header is not rendered.

Solution:
I couldn't reproduce the issue. This is an attempt by making clear the header will not even try to render if NightlyWallet is present, passing this logic to JavaScript rather then CSS classes mediated by `clsx`. It also logs when NigthlyWallet is present.