### PR TITLE
fix: grid items alignment and flex grow of images

### DIFF
--- a/frontend/src/components/ClientCard.tsx
+++ b/frontend/src/components/ClientCard.tsx
@@ -41,12 +41,21 @@ const ClientCard: React.FC<ClientCardProps> = ({
         transition: 'transition: opacity 0.6s ease-out 0.25s, transform 0.6s ease-out 0.25s',
       }}
     >
-      <div className='flex-1 overflow-hidden rounded-3xl'>
-        <img className='h-full w-full object-cover' src={image} alt={alt} />
+      <div className='flex-2 overflow-hidden rounded-3xl'>
+        <img
+          className='h-full w-full object-cover'
+          src={image}
+          alt={alt}
+          style={{
+            aspectRatio: '16/9',
+          }}
+        />
       </div>
 
-      <div className='p-3 md:p-4'>
-        <h4 className='mb-1 text-base font-semibold text-gray-900 md:text-lg'>{title}</h4>
+      <div className='flex-1 p-3 md:p-4'>
+        <h4 className='mb-1 align-baseline text-base font-semibold text-gray-900 md:text-lg'>
+          {title}
+        </h4>
         <p className='text-base text-gray-600 md:text-xl'>{description}</p>
       </div>
     </div>

--- a/frontend/src/components/FeaturesGrid.tsx
+++ b/frontend/src/components/FeaturesGrid.tsx
@@ -17,6 +17,7 @@ interface FeaturesGridProps {
   width?: string;
   opacity?: number;
   translateY?: number;
+  alignItems?: string;
   gap?: string;
   pb?: string;
   delay?: number;
@@ -28,6 +29,7 @@ const FeaturesGrid: React.FC<FeaturesGridProps> = ({
   width = 'max-w-5xl',
   opacity = 0,
   translateY = 4,
+  alignItems = 'normal',
   gap = 'gap-6',
   pb = 'pb-12',
   delay = 200,
@@ -41,6 +43,7 @@ const FeaturesGrid: React.FC<FeaturesGridProps> = ({
       )}
       style={{
         transition: 'opacity 0.6s ease-out 0.35s, transform 0.6s ease-out 0.35s',
+        alignItems,
       }}
     >
       {children}

--- a/frontend/src/components/IntroSlide11.tsx
+++ b/frontend/src/components/IntroSlide11.tsx
@@ -28,7 +28,13 @@ const IntroSlide11: React.FC = () => {
         </SlideDescription>
       </div>
 
-      <FeaturesGrid columns='sm:grid-cols-2' width='max-w-6xl' gap='gap-10' pb='pb-20'>
+      <FeaturesGrid
+        columns='sm:grid-cols-2'
+        width='max-w-6xl'
+        gap='gap-10'
+        pb='pb-20'
+        alignItems='baseline'
+      >
         <ClientCard
           image={INTRO_SLIDE_11.content.walletOptions[0].image}
           alt={INTRO_SLIDE_11.content.walletOptions[0].alt}


### PR DESCRIPTION
Problem:
Different grow ratio between images in the grid of IntroSlide11.