### PR TITLE
fix: reward distributed balance by searching by coin type

### DIFF
--- a/frontend/src/helpers/serviceHistory.ts
+++ b/frontend/src/helpers/serviceHistory.ts
@@ -8,6 +8,7 @@ import type { BalanceChange } from '@iota/iota-sdk/client';
 import { IotaEvent, IotaTransactionBlockResponse, OwnedObjectRef } from '@iota/iota-sdk/client';
 
 import { ServiceEntry } from '@/types/transaction';
+import { REWARD_TOKEN_SYMBOL } from '@/utils/constants';
 
 /*
 Service History Data Structure:
@@ -175,7 +176,7 @@ function extractServiceTransactionData(
 const findBalanceChangeByCoinType =
   (packageId: string) =>
   (value: BalanceChange): boolean => {
-    return value.coinType === `${packageId}::LCC::LCC`;
+    return value.coinType === `${packageId}::${REWARD_TOKEN_SYMBOL}::${REWARD_TOKEN_SYMBOL}`;
   };
 
 // Export all interfaces and functions


### PR DESCRIPTION
Problem:
Some transactions were showing 0 as reward distributed, but it is not the case, all transactions receive a reward. This was only possible because balance was getting the last BalanceChange in a list, however this list is not position determinant.

Solution:
Find the right BalanceChange in the list by CoinType, leveraging the knowledge about the PackageID.